### PR TITLE
Remove empty format precision specifier

### DIFF
--- a/src/generator.rs
+++ b/src/generator.rs
@@ -16,7 +16,7 @@ impl Display for Value {
         match self {
             Self::Integer(v) => v.fmt(f),
             // See: https://doc.rust-lang.org/std/fmt/index.html
-            Self::Float(v) => write!(f, "{:.?}", v),
+            Self::Float(v) => write!(f, "{:?}", v),
             Self::Boolean(v) => v.fmt(f),
             Self::String(v) => v.fmt(f),
             Self::Array(v) => indent_inbetween(f, &v.to_string()),


### PR DESCRIPTION
A format precision specifier consisting of a dot and no number actually does nothing and has no specified meaning. Currently this is silently ignored, but it may turn into a warning or error.

See https://github.com/rust-lang/rust/issues/131159 and https://github.com/rust-lang/rust/pull/136638

Please leave a comment there if you have any opinion about this. If you remember why this was written this way that could help improve the diagnostics rustc gives.